### PR TITLE
bitflags: several changes

### DIFF
--- a/bitflags.h
+++ b/bitflags.h
@@ -1,18 +1,18 @@
 
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2016 Herb Sutter. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2016 Herb Sutter. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
 
@@ -21,8 +21,10 @@
 
 #include "util.h"
 
-#include <vector>
+#include <climits>
+#include <memory>
 #include <algorithm>
+#include <type_traits>
 
 namespace gcpp {
 
@@ -33,22 +35,61 @@ namespace gcpp {
 	//----------------------------------------------------------------------------
 
 	class bitflags {
+		using unit = unsigned int;
+		static_assert(std::is_unsigned<unit>::value, "unit must be an unsigned integral type.");
+
+		std::unique_ptr<unit[]> bits;
 		const int size;
-		std::vector<byte> bits;
+
+		static constexpr auto bits_per_unit = static_cast<int>(sizeof(unit) * CHAR_BIT);
+
+		//  Return a unit with all bits set if "set" is true, or all bits cleared otherwise.
+		//
+		static constexpr unit all_bits(bool set) {
+			return set ? ~unit(0) : unit(0);
+		}
+
+		//  Return a mask that will select the bit at position from its unit
+		//
+		static unit bit_mask(int at) {
+			Expects(0 <= at && "position must be non-negative");
+			return unit(1) << (at % bits_per_unit);
+		}
+
+		//  Return the number of units needed to represent a number of bits
+		//
+		static int unit_count(int bit_count) {
+			Expects(0 <= bit_count && "bit_count must be non-negative");
+			return (bit_count + bits_per_unit - 1) / bits_per_unit;
+		}
+
+		//  Get the unit that contains the bit at position
+		//
+		unit& bit_unit(int at) {
+			Expects(0 <= at && "position must be non-negative");
+			return bits[at / bits_per_unit];
+		}
+		const unit& bit_unit(int at) const {
+			Expects(0 <= at && "position must be non-negative");
+			return bits[at / bits_per_unit];
+		}
 
 	public:
-		bitflags(int bits, bool value)
-			: size{ bits }
-			, bits(1 + size / sizeof(byte), value ? byte(0xFF) : byte(0x00))
-		{ 
-			Expects(bits > 0 && "#bits must be positive");
+		bitflags(int nbits, bool value)
+			: size{ nbits }
+		{
+			Expects(nbits >= 0 && "#bits must be non-negative");
+			bits = std::make_unique<unit[]>(unit_count(nbits));
+			if (value) {
+				set_all(true);
+			}
 		}
 
 		//	Get flag value at position
 		//
 		bool get(int at) const {
 			Expects(0 <= at && at < size && "bitflags get() out of range");
-			return (bits[at / sizeof(byte)] & byte(1 << (at % sizeof(byte)))) > byte(0);
+			return (bit_unit(at) & bit_mask(at)) != unit(0);
 		}
 
 		//	Set flag value at position
@@ -56,36 +97,73 @@ namespace gcpp {
 		void set(int at, bool value) {
 			Expects(0 <= at && at < size && "bitflags set() out of range");
 			if (value) {
-				bits[at / sizeof(byte)] |= byte(1 << (at % sizeof(byte)));
+				bit_unit(at) |= bit_mask(at);
 			}
 			else {
-				bits[at / sizeof(byte)] &= byte(0xff ^ (1 << (at % sizeof(byte))));
+				bit_unit(at) &= ~bit_mask(at);
 			}
 		}
 
 		//	Set all flags to value
 		//
 		void set_all(bool value) {
-			std::fill(begin(bits), end(bits), value ? byte(0xFF) : byte(0x00));
+			std::fill_n(bits.get(), unit_count(size), all_bits(value));
 		}
 
 		//	Set all flags in positions [from,to) to value
 		//
 		void set(int from, int to, bool value) {
-			// first set the remaining bits in the partial byte this range begins within
-			while (from < to && from % sizeof(byte) != 0) {
-				set(from++, value);
+			if (from >= to) {
+				return;
 			}
 
-			// then set whole bytes (makes a significant performance difference)
-			while (from < to && to - from >= sizeof(byte)) {
-				bits[from / sizeof(byte)] = value ? byte(0xFF) : byte(0x00);
-				from += sizeof(byte);
+			Expects(0 <= from && to <= size && "bitflags set() out of range");
+
+			const auto from_unit = from / bits_per_unit;
+			const auto from_mod = from % bits_per_unit;
+			const auto to_unit = to / bits_per_unit;
+			const auto to_mod = to % bits_per_unit;
+
+			const auto n_whole_units = to_unit - from_unit - 1;
+			auto data = bits.get() + from_unit;
+
+			// first set the remaining bits in the partial unit this range begins within
+			if (from_mod != 0) {
+				// set all bits less than from in a mask
+				auto mask = (unit(1) << from_mod) - 1;
+				if (n_whole_units < 0) {
+					 // set all bits in mask that are >= to as well
+					mask |= ~((unit(1) << to_mod) - 1);
+				}
+
+				if (value) {
+					*data |= ~mask;
+				}
+				else {
+					*data &= mask;
+				}
+
+				if (n_whole_units < 0) {
+					return;
+				}
+
+				++data;
 			}
 
-			// then set the remaining bits in the partial byte this range ends within
-			while (from < to) {
-				set(from++, value);
+			// then set whole units (makes a significant performance difference)
+			data = std::fill_n(data, n_whole_units, all_bits(value));
+
+			// then set the remaining bits in the partial unit this range ends within
+			if (to_mod != 0) {
+				// set all bits less than to in a mask
+				auto mask = (unit(1) << to_mod) - 1;
+
+				if (value) {
+					*data |= mask;
+				}
+				else {
+					*data &= ~mask;
+				}
 			}
 		}
 	};


### PR DESCRIPTION
* `byte` is an odd choice for the units of a bit vector: we care that it's a bag of bits, there's no reason to use the "fundamental unit of addressable storage" type. Instead use the symbolic type `unit`, currently a `typedef` to `unsigned int` so `set(from, to, value)` can process bigger chunks.

* `sizeof(byte)` is not the number of bits in a unit; it is a complicated spelling of `1`. `bitflags` is therefore `CHAR_BIT` times as large as it needs to be. Replace uses of `sizeof(byte)` with `bits_per_unit` which is `sizeof(unit) * CHAR_BIT`.

* Factor the complex "bit addressing" expressions into separate functions to simplify.

* Use `std::unique_ptr<unit[]>` for bit storage instead of `std::vector<unit>`; some guy said in a talk at CPPCon that we're supposed to use `std::unique_ptr<T[]>` to "express a fixed-but-dynamic-size member array" ;)

* Improve codegen for `set(from, to, value)` by implementing the head and tail loops in O(1) with bit shift/mask operations.
