### PR TITLE
Enable CMake build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/GSL"]
+	path = submodules/GSL
+	url = https://github.com/Microsoft/GSL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "submodules/GSL"]
-	path = submodules/GSL
+[submodule "submodules/gsl"]
+	path = submodules/gsl
 	url = https://github.com/Microsoft/GSL.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/submodules/gsl)
+
+add_executable(test_basic test.cpp)
+add_executable(test_graph test_graph.cpp)
+
+enable_testing()
+
+add_test(test_basic ${CMAKE_BINARY_DIR}/test_basic -s)
+add_test(test_graph ${CMAKE_BINARY_DIR}/test_graph -s)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import sys
+import os
+import subprocess
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tests", help="run tests", action="store_true", dest="run_tests")
+    parser.add_argument("--output", help="output dir (relative to source dir)", default="build", dest="out_dir")
+    parser.add_argument("--config", help="build config", default="Debug", dest="config")
+    args = parser.parse_args()
+    
+    src_dir = os.path.dirname(os.path.dirname(__file__))
+    
+    subprocess.check_call("cmake . -B{} -DCMAKE_BUILD_TYPE={}".format(args.out_dir, args.config).split(), cwd=src_dir)
+    subprocess.check_call("cmake --build ./{}".format(args.out_dir).split(), cwd=src_dir)
+    
+    if args.run_tests:
+        rc = subprocess.call("ctest . --output-on-failure".split(), cwd=os.path.join(src_dir,args.out_dir))
+        if rc != 0:
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/test_graph.cpp
+++ b/test_graph.cpp
@@ -141,7 +141,7 @@ bool TestCase3() {
 	return Counter::count() == 4;
 }
 
-int _main() {
+int main() {
 	cout.setf(ios::boolalpha);
 
 	bool passed1 = TestCase1();


### PR DESCRIPTION
This PR allows test binaries to build built and executed on OS X and Linux (and Windows) with a Python script:

python ./scripts/build.py --tests
I've added a CMakeLists file, a Python build script that triggers CMake and added GSL to a submodule.

I can break this PR up if only bits of it are useful.

I will follow this up with a Travis-CI PR to enable CI on Linux and macOS.

This PR replaces #10 with identical functionality but correct handling of case-sensitive filenames.