### PR TITLE
* gpage.h:

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -1,18 +1,18 @@
 
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2016 Herb Sutter. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2016 Herb Sutter. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
 
@@ -84,21 +84,25 @@ void test_page() {
 	g.debug_print();
 
 	auto p1 = g.allocate<char>();
+	(void)p1;
 	g.debug_print();
 
 	auto p2 = g.allocate<double>();
+	(void)p2;
 	g.debug_print();
 
 	auto p3 = g.allocate<char>();
 	g.debug_print();
 
 	auto p4 = g.allocate<double>();
+	(void)p4;
 	g.debug_print();
 
 	g.deallocate(p3);
 	g.debug_print();
 
 	auto p5 = g.allocate<char>();
+	(void)p5;
 	g.debug_print();
 }
 
@@ -227,7 +231,7 @@ void test_deferred_allocator() {
 //----------------------------------------------------------------------------
 
 void test_deferred_allocator_set() {
-#ifndef __GNUC__
+#if !defined(__GLIBCXX__) && !defined(_LIBCPP_VERSION)
 	deferred_heap heap;
 
 	auto s = deferred_set<widget>(heap);

--- a/util.h
+++ b/util.h
@@ -1,18 +1,18 @@
 
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2016 Herb Sutter. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2016 Herb Sutter. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
 
@@ -26,10 +26,12 @@
 
 //	This project requires GSL, see: https://github.com/microsoft/gsl
 #include <gsl/gsl>
+#include <limits>
+#include <type_traits>
 
 namespace gcpp {
 
-	using byte = gsl::byte;
+	using gsl::byte;
 
 }
 
@@ -42,5 +44,15 @@ bool operator< (const Type& that) const { return compare3(that) <  0; } \
 bool operator<=(const Type& that) const { return compare3(that) <= 0; } \
 bool operator> (const Type& that) const { return compare3(that) >  0; } \
 bool operator>=(const Type& that) const { return compare3(that) >= 0; }
+
+//  Returns true iff value is within the range of values representable by (arithmetic) type Target
+template<class Target, class Value>
+constexpr bool in_representable_range(Value const& value) {
+	using C = std::common_type_t<Target, Value>;
+	auto const cvalue = static_cast<C>(value);
+	return cvalue <= static_cast<C>(std::numeric_limits<Target>::max()) &&
+		(!std::is_signed<C>::value || static_cast<C>(std::numeric_limits<Target>::min()) <= cvalue) &&
+		(C{} < cvalue) == (Value{} < value);
+}
 
 #endif


### PR DESCRIPTION
  * narrow the result of `locations()` *after* the division to raise the maximum page size by a few more bits. (Verify in the constructor that `total_size / min_alloc <= INT_MAX` so that `locations()` is guaranteed to be representable.)
  * `inuse` and `starts` both need to hold only one bit per location, not one bit per byte.
  * In the loop in `allocate()` that is searching for an available space, ensure that we do not misalign `i` when stepping over an allocated location at `j`.
  * In `contains()`, use `std::less<>` to compare pointers into potentially differing pages. (`<` is not portably a total function on pointers, `std::less` is portably total.) Avoid the same issue in `deallocate` by checking `contains()` before calculating the difference of the page base pointer and the function argument.
  * In `lowest_hex_digits_of_address`, convert the pointer to `uintptr_t` instead of `size_t`.
  * In `debug_print`, don't end lines with `" \n"` when `"\n"` will do ;)

* deferred_heap.h:
  * Convert the placement argument to `void*` to ensure we're invoking True Placement New in `construct` and `construct_array`.
  * In `construct_array`, construct the `n` elements in `n` contiguous memory locations instead of in a single memory location. If a constructor throws, cleanup the constructed elements before allowing the exception to propagate.
  * In `collect`, don't pass `pg.page.locations()` to `pg.page.location_info()`. It's out-of-range.

* test.cpp:
  * Tell the compiler not to warn that `p1`, `p2`, `p4`, & `p5` are unused in `test_page`.
  * In `test_deferred_allocator_set`, test explicitly for libstdc++ and libc++ whose implementations of `std::set` do not like this test.
