### PR TITLE
Improve code readability on README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See also [additional uses of deferred_allocator](#speculative-stl-iterator-safet
 
 Here is a `Graph` type that has its own local heap shared by all `Graph` objects:
 
-~~~
+~~~cpp
 // possibly-cyclic N-ary Graph, one heap for all graph nodes
 
 class Graph {
@@ -77,7 +77,7 @@ public:
 
 Here is a variation where each `Graph` object has its own private local heap: 
 
-~~~
+~~~cpp
 // possibly-cyclic N-ary Graph, one heap per graph object
 
 class Graph {


### PR DESCRIPTION
Code blocks were missing the language specifiers, so they weren't nicely highlighted.
Result:
![screenshot_2016-09-28_19-03-54](https://cloud.githubusercontent.com/assets/5068286/18934123/792e1d1a-85ae-11e6-991c-98207f2a54c3.png)
