### PR TITLE
Add CMake artifact and Linux executables to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 *.exe
 *.out
 *.app
+test_basic
+test_graph
 
 # VS artifacts
 *.sln
@@ -34,6 +36,12 @@
 *.vcxproj
 *.filters
 *.opendb
+
+# CMake artifacts
+CMakeCache.txt
+CmakeFiles/
+Makefile
+*.cmake
 
 # Subdirectories
 */


### PR DESCRIPTION
Just a small contribution.  CMake leaves a few artifacts in its wake.  Also, executables on the Linux build have no extension and thus need to be specified explicitly.